### PR TITLE
style(scripts): 修正 cd.js 文件中的 MIME 类型限制

### DIFF
--- a/scripts/cd.js
+++ b/scripts/cd.js
@@ -29,7 +29,7 @@ const folderPath = 'dist'; // 需要上传的本地文件夹路径
 const mac = new qiniu.auth.digest.Mac(accessKey, secretKey);
 const options = {
     scope: bucket,
-    mimeLimit: 'image/*;text/html,text/css,application/javascript,application/json',
+    mimeLimit: 'image/*,text/html,text/css,application/javascript,application/json',
 };
 const putPolicy = new qiniu.rs.PutPolicy(options);
 const uploadToken = putPolicy.uploadToken(mac);


### PR DESCRIPTION
- 将 mimeLimit 参数中的斜杠和逗号统一为英文字符- 优化代码格式，提高可读性