### PR TITLE
fix(scripts): 修正文件类型限制正则表达式

### DIFF
--- a/scripts/cd.js
+++ b/scripts/cd.js
@@ -29,7 +29,7 @@ const folderPath = 'dist'; // 需要上传的本地文件夹路径
 const mac = new qiniu.auth.digest.Mac(accessKey, secretKey);
 const options = {
     scope: bucket,
-    mimeLimit: 'image/*,text/html,text/css,application/javascript,application/json',
+    mimeLimit: 'image/*;text/html;text/css;text/javascript;application/json',
 };
 const putPolicy = new qiniu.rs.PutPolicy(options);
 const uploadToken = putPolicy.uploadToken(mac);


### PR DESCRIPTION
-将 mimeLimit 选项中的文件类型分隔符从逗号改为分号
- 这个修改可以确保文件类型限制的正确性和兼容性